### PR TITLE
If a notification fails due to "Bad Attachment" then retry without it.

### DIFF
--- a/LegoSetNotifier.Test/AppriseNotifierTests.cs
+++ b/LegoSetNotifier.Test/AppriseNotifierTests.cs
@@ -1,0 +1,74 @@
+﻿using LegoSetNotifier.AppriseApi;
+using LegoSetNotifier.RebrickableData;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using System.Net;
+
+namespace LegoSetNotifier.Test
+{
+    [TestClass]
+    public class AppriseNotifierTests
+    {
+        [TestMethod]
+        public async Task TestNewSetNotificationNoExceptionAsync()
+        {
+            var testLegoSet = new LegoSet()
+            {
+                Name = "Test Lego Set",
+            };
+
+            var mockApiClient = Substitute.For<IAppriseApiClient>();
+            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
+
+            var notifier = new AppriseNotifier(mockApiClient, "testkey");
+            await notifier.SendNewSetNotificationAsync(testLegoSet);
+
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Title.Contains(testLegoSet.Name)));
+        }
+
+        [TestMethod]
+        public async Task TestNewSetNotificationBadAttachmentRetryAsync()
+        {
+            var testLegoSet = new LegoSet()
+            {
+                Name = "Test Lego Set",
+                ImageUrl = "ruhroh",
+            };
+
+            var mockApiClient = Substitute.For<IAppriseApiClient>();
+            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Is<AppriseApiNotifyContent>(r => r.Attach != null)).
+                Returns(x => { throw new AppriseApiException("{\"error\": \"Bad Attachment\"}", new HttpRequestException()); });
+            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Is<AppriseApiNotifyContent>(r => r.Attach == null)).
+                Returns(Task.CompletedTask);
+
+            var notifier = new AppriseNotifier(mockApiClient, "testkey");
+            await notifier.SendNewSetNotificationAsync(testLegoSet);
+
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Attach == null));
+        }
+
+        [TestMethod]
+        public async Task TestErrorNotificationWithExAsync()
+        {
+            var mockApiClient = Substitute.For<IAppriseApiClient>();
+            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
+
+            var notifier = new AppriseNotifier(mockApiClient, "testkey");
+            await notifier.SendErrorNotificationAsync("Test Error Message", new InvalidOperationException());
+
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains("Test Error Message") && r.Body.Contains("InvalidOperationException")));
+        }
+
+        [TestMethod]
+        public async Task TestErrorNotificationWithoutExAsync()
+        {
+            var mockApiClient = Substitute.For<IAppriseApiClient>();
+            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
+
+            var notifier = new AppriseNotifier(mockApiClient, "testkey");
+            await notifier.SendErrorNotificationAsync("Test Error Message", null);
+
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains("Test Error Message")));
+        }
+    }
+}

--- a/LegoSetNotifier/AppriseApi/AppriseApiClient.cs
+++ b/LegoSetNotifier/AppriseApi/AppriseApiClient.cs
@@ -1,0 +1,62 @@
+﻿using System.Text;
+using System.Text.Json;
+
+namespace LegoSetNotifier.AppriseApi
+{
+    public class AppriseApiClient : IAppriseApiClient, IDisposable
+    {
+        private readonly string baseUrl;
+
+        private HttpClient httpClient;
+        private bool disposedValue = false;
+
+        public AppriseApiClient(string baseUrl)
+        {
+            this.baseUrl = baseUrl;
+
+            this.httpClient = new HttpClient();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.disposedValue)
+            {
+                if (disposing)
+                {
+                    this.httpClient.Dispose();
+                }
+
+                this.disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            this.Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        public async Task NotifyAsync(string configKey, AppriseApiNotifyContent notifyRequest)
+        {
+            using (var request = new HttpRequestMessage(HttpMethod.Post, $"{this.baseUrl}/notify/{configKey}"))
+            {
+                var apprisePayloadString = JsonSerializer.Serialize(notifyRequest);
+                request.Content = new StringContent(apprisePayloadString, Encoding.UTF8, "application/json");
+
+                var response = await this.httpClient.SendAsync(request);
+
+                var responseString = await response.Content.ReadAsStringAsync();
+
+                try
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+                catch (Exception ex) when (!string.IsNullOrEmpty(responseString))
+                {
+                    throw new AppriseApiException(responseString, ex);
+                }
+            }
+        }
+    }
+}

--- a/LegoSetNotifier/AppriseApi/AppriseApiException.cs
+++ b/LegoSetNotifier/AppriseApi/AppriseApiException.cs
@@ -1,0 +1,41 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace LegoSetNotifier.AppriseApi
+{
+    public class AppriseApiException : AggregateException
+    {
+        public string ErrorMessage { get; set; } = string.Empty;
+
+        public AppriseApiException(string responseString, Exception innerException) :
+            base(responseString, innerException)
+        {
+            this.ErrorMessage = GetErrorMsgFromResponseString(responseString);
+        }
+
+        static private string GetErrorMsgFromResponseString(string responseString)
+        {
+            try
+            {
+                var responseObject = JsonSerializer.Deserialize<JsonObject>(responseString);
+                if (responseObject == null)
+                {
+                    return string.Empty;
+                }
+
+                var responseError = responseObject["error"];
+                if (responseError == null)
+                {
+                    return string.Empty;
+                }
+
+                return responseError.ToString();
+            }
+            catch (Exception)
+            {
+                // We're already generating an exception, so another exception here wouldn't be helpful.
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/LegoSetNotifier/AppriseApi/AppriseApiNotifyContent.cs
+++ b/LegoSetNotifier/AppriseApi/AppriseApiNotifyContent.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+
+namespace LegoSetNotifier.AppriseApi
+{
+    public class AppriseApiNotifyContent
+    {
+        [JsonPropertyName("body")]
+        public string Body { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "info";
+
+        [JsonPropertyName("tag")]
+        public string Tag { get; set; } = "all";
+
+        [JsonPropertyName("format")]
+        public string Format { get; set; } = "text";
+
+        [JsonPropertyName("attach")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? Attach { get; set; } = null;
+    }
+}

--- a/LegoSetNotifier/AppriseApi/IAppriseApiClient.cs
+++ b/LegoSetNotifier/AppriseApi/IAppriseApiClient.cs
@@ -1,0 +1,7 @@
+﻿namespace LegoSetNotifier.AppriseApi
+{
+    public interface IAppriseApiClient
+    {
+        public Task NotifyAsync(string configKey, AppriseApiNotifyContent notifyRequest);
+    }
+}

--- a/LegoSetNotifier/Program.cs
+++ b/LegoSetNotifier/Program.cs
@@ -1,4 +1,5 @@
-﻿using LegoSetNotifier.RebrickableData;
+﻿using LegoSetNotifier.AppriseApi;
+using LegoSetNotifier.RebrickableData;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Mono.Options;
@@ -14,13 +15,15 @@ namespace LegoSetNotifier
 
             var printHelp = false;
             var dataFilePath = "previouslySeen.json";
-            var appriseNotifyUrl = string.Empty;
+            var appriseApiBaseUrl = string.Empty;
+            var appriseApiConfigKey = string.Empty;
 
             var options = new OptionSet()
             {
                 { "help", "Print help text", _ => printHelp = true },
                 { "f|data-file=", $"Data file path, default: {dataFilePath}", o => dataFilePath = o },
-                { "n|apprise-notifyurl=", $"Apprise notify url, default: {appriseNotifyUrl}", o => appriseNotifyUrl = o },
+                { "a|apprise-api-baseurl=", $"Apprise API base URL, default: {appriseApiBaseUrl}", o => appriseApiBaseUrl = o },
+                { "k|apprise-api-configkey=", $"Apprise API config key, default: {appriseApiConfigKey}", o => appriseApiConfigKey = o },
             };
             options.Parse(args);
 
@@ -30,14 +33,30 @@ namespace LegoSetNotifier
                 return 0;
             }
 
+            // Options validation: either both Apprise API [base URL + config key] must be specified, or neither.
+            if (!string.IsNullOrEmpty(appriseApiBaseUrl) && string.IsNullOrEmpty(appriseApiConfigKey))
+            {
+                logger.LogError("Invalid options, cannot only provide Apprise API base URL (must also provide config key)");
+                options.WriteOptionDescriptions(Console.Out);
+                return -1;
+            }
+            else if (!string.IsNullOrEmpty(appriseApiConfigKey) && string.IsNullOrEmpty(appriseApiBaseUrl))
+            {
+                logger.LogError("Invalid options, cannot only provide Apprise API config key (must also provide base URL)");
+                options.WriteOptionDescriptions(Console.Out);
+                return -1;
+            }
+
+            AppriseApiClient? appriseClient = null;
             INotifier? notifier = null;
             try
             {
                 var seenData = await PreviouslySeenDataJsonFile.FromFilePathAsync(dataFilePath);
 
-                if (!string.IsNullOrEmpty(appriseNotifyUrl))
+                if (!string.IsNullOrEmpty(appriseApiBaseUrl))
                 {
-                    notifier = new AppriseNotifier(appriseNotifyUrl);
+                    appriseClient = new AppriseApiClient(appriseApiBaseUrl);
+                    notifier = new AppriseNotifier(appriseClient, appriseApiConfigKey);
                 }
 
                 using (var dataClient = new RebrickableDataClient())
@@ -54,6 +73,13 @@ namespace LegoSetNotifier
                 if (notifier != null)
                 {
                     await notifier.SendErrorNotificationAsync(exceptionErrorMessage, ex);
+                }
+            }
+            finally
+            {
+                if (appriseClient != null)
+                {
+                    appriseClient.Dispose();
                 }
             }
 


### PR DESCRIPTION
To make this retry behavior unit-testable, Apprise API integration is now implemented separately from the program's more-domain-specific Notifier.  `AppriseApiClient` isn't yet a reusable module, but it's getting there...