### PR TITLE
Improved batching behavior, including the initialization case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/Properties/launchSettings.json
 
+notifications
 publish_output
 
 ## Ignore Visual Studio temporary files, build results, and

--- a/LegoSetNotifier.Test/AppriseNotifierTests.cs
+++ b/LegoSetNotifier.Test/AppriseNotifierTests.cs
@@ -17,7 +17,7 @@ namespace LegoSetNotifier.Test
                 Body = "Test Notification Content",
             };
             var testNotification = Substitute.For<LegoSetBatchNotification>();
-            testNotification.GetContent().Returns(testContent);
+            testNotification.GetNotificationContent().Returns(testContent);
 
             var mockApiClient = Substitute.For<IAppriseApiClient>();
             mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
@@ -39,7 +39,7 @@ namespace LegoSetNotifier.Test
                 Attachments = new List<string>() { "ruhroh" },
             };
             var testNotification = Substitute.For<LegoSetBatchNotification>();
-            testNotification.GetContent().Returns(testContent);
+            testNotification.GetNotificationContent().Returns(testContent);
 
             var mockApiClient = Substitute.For<IAppriseApiClient>();
             mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Is<AppriseApiNotifyContent>(r => r.Attachments.Count > 0)).

--- a/LegoSetNotifier.Test/AppriseNotifierTests.cs
+++ b/LegoSetNotifier.Test/AppriseNotifierTests.cs
@@ -10,35 +10,36 @@ namespace LegoSetNotifier.Test
     public class AppriseNotifierTests
     {
         [TestMethod]
-        public async Task TestNewSetsNotificationNoExceptionAsync()
+        public async Task TestNotificationNoExceptionAsync()
         {
-            var testLegoSet = new LegoSet()
+            var testContent = new AppriseApiNotifyContent()
             {
-                Name = "Test Lego Set",
-                ExtendedSetNumber = "12345-1",
+                Body = "Test Notification Content",
             };
+            var testNotification = Substitute.For<LegoSetBatchNotification>();
+            testNotification.GetContent().Returns(testContent);
 
             var mockApiClient = Substitute.For<IAppriseApiClient>();
             mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
 
             var notifier = new AppriseNotifier(mockApiClient, "testkey");
             notifier.NotificationCooldownTime = TimeSpan.Zero;
-            var notifiedSetNumbers = await notifier.SendNewSetsNotificationAsync(new List<LegoSet>() { testLegoSet });
-            Assert.HasCount(1, notifiedSetNumbers);
-            Assert.Contains(testLegoSet.ExtendedSetNumber, notifiedSetNumbers);
+            var success = await notifier.SendLegoSetBatchNotificationAsync(testNotification);
+            Assert.IsTrue(success);
 
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains(testLegoSet.Name)));
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(testContent));
         }
 
         [TestMethod]
-        public async Task TestNewSetsNotificationBadAttachmentRetryAsync()
+        public async Task TestNotificationBadAttachmentRetryAsync()
         {
-            var testLegoSet = new LegoSet()
+            var testContent = new AppriseApiNotifyContent()
             {
-                Name = "Test Lego Set",
-                ExtendedSetNumber = "12345-1",
-                ImageUrl = "ruhroh",
+                Body = "Test Notification Content",
+                Attachments = new List<string>() { "ruhroh" },
             };
+            var testNotification = Substitute.For<LegoSetBatchNotification>();
+            testNotification.GetContent().Returns(testContent);
 
             var mockApiClient = Substitute.For<IAppriseApiClient>();
             mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Is<AppriseApiNotifyContent>(r => r.Attachments.Count > 0)).
@@ -48,104 +49,15 @@ namespace LegoSetNotifier.Test
 
             var notifier = new AppriseNotifier(mockApiClient, "testkey");
             notifier.NotificationCooldownTime = TimeSpan.Zero;
-            var notifiedSetNumbers = await notifier.SendNewSetsNotificationAsync(new List<LegoSet>() { testLegoSet });
-            Assert.HasCount(1, notifiedSetNumbers);
-            Assert.Contains(testLegoSet.ExtendedSetNumber, notifiedSetNumbers);
+            var success = await notifier.SendLegoSetBatchNotificationAsync(testNotification);
+            Assert.IsTrue(success);
 
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Attachments.Count == 0));
-        }
-
-        [TestMethod]
-        public async Task TestNewSetsNotificationMultipleSetsAsync()
-        {
-            var testLegoSet1 = new LegoSet()
-            {
-                Name = "Test Lego Set 1",
-                ExtendedSetNumber = "00001-1",
-            };
-            var testLegoSet2 = new LegoSet()
-            {
-                Name = "Test Lego Set 2",
-                ExtendedSetNumber = "00002-1",
-            };
-
-            var mockApiClient = Substitute.For<IAppriseApiClient>();
-            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
-
-            var notifier = new AppriseNotifier(mockApiClient, "testkey");
-            notifier.NotificationCooldownTime = TimeSpan.Zero;
-            var notifiedSetNumbers = await notifier.SendNewSetsNotificationAsync(new List<LegoSet>() { testLegoSet1, testLegoSet2 });
-            Assert.HasCount(2, notifiedSetNumbers);
-            Assert.Contains(testLegoSet1.ExtendedSetNumber, notifiedSetNumbers);
-            Assert.Contains(testLegoSet2.ExtendedSetNumber, notifiedSetNumbers);
-
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains(testLegoSet1.Name) && r.Body.Contains(testLegoSet2.Name)));
-        }
-
-        [TestMethod]
-        public async Task TestNewSetsNotificationMoreThanOneBatchAsync()
-        {
-            // To induce unusually-large notification bodies, inflate the sets' Name strings.
-            var largeStringLength = (AppriseNotifier.MaxBodyChars / 3) + 1;
-            var testLegoSet1 = new LegoSet()
-            {
-                Name = StringGenerator.Generate(largeStringLength),
-                ExtendedSetNumber = "00001-1",
-            };
-            var testLegoSet2 = new LegoSet()
-            {
-                Name = StringGenerator.Generate(largeStringLength),
-                ExtendedSetNumber = "00002-1",
-            };
-            var testLegoSet3 = new LegoSet()
-            {
-                Name = StringGenerator.Generate(largeStringLength),
-                ExtendedSetNumber = "00003-1",
-            };
-            var testLegoSet4 = new LegoSet()
-            {
-                Name = StringGenerator.Generate(largeStringLength),
-                ExtendedSetNumber = "00004-1",
-            };
-
-            var mockApiClient = Substitute.For<IAppriseApiClient>();
-            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
-
-            var notifier = new AppriseNotifier(mockApiClient, "testkey");
-            notifier.NotificationCooldownTime = TimeSpan.Zero;
-            var notifiedSetNumbers = await notifier.SendNewSetsNotificationAsync(new List<LegoSet>() { testLegoSet1, testLegoSet2, testLegoSet3, testLegoSet4 });
-            Assert.HasCount(4, notifiedSetNumbers);
-            Assert.Contains(testLegoSet1.ExtendedSetNumber, notifiedSetNumbers);
-            Assert.Contains(testLegoSet2.ExtendedSetNumber, notifiedSetNumbers);
-            Assert.Contains(testLegoSet3.ExtendedSetNumber, notifiedSetNumbers);
-            Assert.Contains(testLegoSet4.ExtendedSetNumber, notifiedSetNumbers);
-
-            // Assumption: the test data's content lengths should result in two batches (two notifications).
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains(testLegoSet1.Name) && r.Body.Contains(testLegoSet2.Name)));
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => r.Body.Contains(testLegoSet3.Name) && r.Body.Contains(testLegoSet4.Name)));
-        }
-
-        [TestMethod]
-        public async Task TestNewSetsNotificationContentTooBigAsync()
-        {
-            var largeStringLength = AppriseNotifier.MaxBodyChars * 2;
-            var testLegoSet = new LegoSet()
-            {
-                Name = StringGenerator.Generate(largeStringLength),
-                ExtendedSetNumber = "12345-1",
-            };
-
-            var mockApiClient = Substitute.For<IAppriseApiClient>();
-            mockApiClient.NotifyAsync(Arg.Any<string>(), Arg.Any<AppriseApiNotifyContent>()).Returns(Task.CompletedTask);
-
-            var notifier = new AppriseNotifier(mockApiClient, "testkey");
-            notifier.NotificationCooldownTime = TimeSpan.Zero;
-            var notifiedSetNumbers = await notifier.SendNewSetsNotificationAsync(new List<LegoSet>() { testLegoSet });
-            Assert.HasCount(1, notifiedSetNumbers);
-            Assert.Contains(testLegoSet.ExtendedSetNumber, notifiedSetNumbers);
-
-            // The oversized data should result in a notification, but without that oversized data.
-            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r => !r.Body.Contains(testLegoSet.Name)));
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r =>
+                r.Type.Equals("failure", StringComparison.Ordinal) &&
+                r.Body.Contains("Bad Attachment", StringComparison.Ordinal)));
+            await mockApiClient.Received().NotifyAsync("testkey", Arg.Is<AppriseApiNotifyContent>(r =>
+                r.Body.Equals(testContent.Body, StringComparison.Ordinal) &&
+                r.Attachments.Count == 0));
         }
 
         [TestMethod]

--- a/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
+++ b/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
@@ -1,0 +1,91 @@
+﻿using LegoSetNotifier.RebrickableData;
+using NSubstitute;
+
+namespace LegoSetNotifier.Test
+{
+    [TestClass]
+    public class LegoSetBatchNotificationTests
+    {
+        [TestMethod]
+        public void TestBuildNotificationsOneBatch()
+        {
+            var mockNotifier = Substitute.For<INotifier>();
+            mockNotifier.GetMaxNotificationBodyChars().Returns(32768u);
+            mockNotifier.GetMaxNotificationAttachments().Returns(32768u);
+
+            var testLegoSet = new LegoSet()
+            {
+                Name = "Test Lego Set",
+                ExtendedSetNumber = "12345-1",
+                ImageUrl = "whatever",
+            };
+
+            var batches = LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet });
+
+            Assert.HasCount(1, batches);
+
+            var batch1 = batches.ElementAt(0);
+            Assert.HasCount(1, batch1.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet.ExtendedSetNumber, batch1.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet.Name, batch1.GetContent().Body);
+            Assert.Contains(testLegoSet.ImageUrl, batch1.GetContent().Attachments);
+        }
+
+        [TestMethod]
+        public async Task TestBuildNotificationsMultipleBatches()
+        {
+            var mockNotifier = Substitute.For<INotifier>();
+            mockNotifier.GetMaxNotificationBodyChars().Returns(32768u);
+            mockNotifier.GetMaxNotificationAttachments().Returns(1u);
+
+            var testLegoSet1 = new LegoSet()
+            {
+                Name = "Test Lego Set 1",
+                ExtendedSetNumber = "00001-1",
+                ImageUrl = "attachment 1",
+            };
+            var testLegoSet2 = new LegoSet()
+            {
+                Name = "Test Lego Set 2",
+                ExtendedSetNumber = "00002-1",
+                ImageUrl = "attachment 2",
+            };
+
+            var batches = LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet1, testLegoSet2 });
+
+            Assert.HasCount(2, batches);
+
+            var batch1 = batches.ElementAt(0);
+            Assert.HasCount(1, batch1.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet1.ExtendedSetNumber, batch1.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet1.Name, batch1.GetContent().Body);
+            Assert.Contains(testLegoSet1.ImageUrl, batch1.GetContent().Attachments);
+
+            var batch2 = batches.ElementAt(1);
+            Assert.HasCount(1, batch2.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet2.ExtendedSetNumber, batch2.GetLegoSetNumbers());
+            Assert.Contains(testLegoSet2.Name, batch2.GetContent().Body);
+            Assert.Contains(testLegoSet2.ImageUrl, batch2.GetContent().Attachments);
+        }
+
+        [TestMethod]
+        public async Task TestBuildNotificationsContentTooBigAsync()
+        {
+            var mockNotifier = Substitute.For<INotifier>();
+            mockNotifier.GetMaxNotificationBodyChars().Returns(2u);
+            mockNotifier.GetMaxNotificationAttachments().Returns(32768u);
+
+            var largeStringLength = mockNotifier.GetMaxNotificationBodyChars() * 2;
+            var testLegoSet = new LegoSet()
+            {
+                Name = StringGenerator.Generate(largeStringLength),
+                ExtendedSetNumber = "12345-1",
+            };
+
+            Assert.ThrowsExactly<InvalidDataException>(() =>
+            {
+                LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet });
+            });
+        }
+    }
+}

--- a/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
+++ b/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
@@ -20,7 +20,10 @@ namespace LegoSetNotifier.Test
                 ImageUrl = "whatever",
             };
 
-            var batches = LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet });
+            var batches = LegoSetBatchNotification.BuildNotifications(
+                mockNotifier,
+                LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                new List<LegoSet>() { testLegoSet });
 
             Assert.HasCount(1, batches);
 
@@ -51,7 +54,10 @@ namespace LegoSetNotifier.Test
                 ImageUrl = "attachment 2",
             };
 
-            var batches = LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet1, testLegoSet2 });
+            var batches = LegoSetBatchNotification.BuildNotifications(
+                mockNotifier,
+                LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                new List<LegoSet>() { testLegoSet1, testLegoSet2 });
 
             Assert.HasCount(2, batches);
 
@@ -84,7 +90,10 @@ namespace LegoSetNotifier.Test
 
             Assert.ThrowsExactly<InvalidDataException>(() =>
             {
-                LegoSetBatchNotification.BuildNotifications(mockNotifier, new List<LegoSet>() { testLegoSet });
+                LegoSetBatchNotification.BuildNotifications(
+                    mockNotifier,
+                    LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                    new List<LegoSet>() { testLegoSet });
             });
         }
     }

--- a/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
+++ b/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
@@ -27,8 +27,8 @@ namespace LegoSetNotifier.Test
             var batch1 = batches.ElementAt(0);
             Assert.HasCount(1, batch1.GetLegoSetNumbers());
             Assert.Contains(testLegoSet.ExtendedSetNumber, batch1.GetLegoSetNumbers());
-            Assert.Contains(testLegoSet.Name, batch1.GetContent().Body);
-            Assert.Contains(testLegoSet.ImageUrl, batch1.GetContent().Attachments);
+            Assert.Contains(testLegoSet.Name, batch1.GetNotificationContent().Body);
+            Assert.Contains(testLegoSet.ImageUrl, batch1.GetNotificationContent().Attachments);
         }
 
         [TestMethod]
@@ -58,14 +58,14 @@ namespace LegoSetNotifier.Test
             var batch1 = batches.ElementAt(0);
             Assert.HasCount(1, batch1.GetLegoSetNumbers());
             Assert.Contains(testLegoSet1.ExtendedSetNumber, batch1.GetLegoSetNumbers());
-            Assert.Contains(testLegoSet1.Name, batch1.GetContent().Body);
-            Assert.Contains(testLegoSet1.ImageUrl, batch1.GetContent().Attachments);
+            Assert.Contains(testLegoSet1.Name, batch1.GetNotificationContent().Body);
+            Assert.Contains(testLegoSet1.ImageUrl, batch1.GetNotificationContent().Attachments);
 
             var batch2 = batches.ElementAt(1);
             Assert.HasCount(1, batch2.GetLegoSetNumbers());
             Assert.Contains(testLegoSet2.ExtendedSetNumber, batch2.GetLegoSetNumbers());
-            Assert.Contains(testLegoSet2.Name, batch2.GetContent().Body);
-            Assert.Contains(testLegoSet2.ImageUrl, batch2.GetContent().Attachments);
+            Assert.Contains(testLegoSet2.Name, batch2.GetNotificationContent().Body);
+            Assert.Contains(testLegoSet2.ImageUrl, batch2.GetNotificationContent().Attachments);
         }
 
         [TestMethod]

--- a/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
+++ b/LegoSetNotifier.Test/LegoSetBatchNotificationTests.cs
@@ -22,7 +22,7 @@ namespace LegoSetNotifier.Test
 
             var batches = LegoSetBatchNotification.BuildNotifications(
                 mockNotifier,
-                LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                LegoSetBatchNotification.FullDetailSettings("Test Notifications"),
                 new List<LegoSet>() { testLegoSet });
 
             Assert.HasCount(1, batches);
@@ -56,7 +56,7 @@ namespace LegoSetNotifier.Test
 
             var batches = LegoSetBatchNotification.BuildNotifications(
                 mockNotifier,
-                LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                LegoSetBatchNotification.FullDetailSettings("Test Notifications"),
                 new List<LegoSet>() { testLegoSet1, testLegoSet2 });
 
             Assert.HasCount(2, batches);
@@ -92,7 +92,7 @@ namespace LegoSetNotifier.Test
             {
                 LegoSetBatchNotification.BuildNotifications(
                     mockNotifier,
-                    LegoSetBatchNotification.NewLegoSetNotificationSettings,
+                    LegoSetBatchNotification.FullDetailSettings("Test Notifications"),
                     new List<LegoSet>() { testLegoSet });
             });
         }

--- a/LegoSetNotifier.Test/LegoSetNotifierTests.cs
+++ b/LegoSetNotifier.Test/LegoSetNotifierTests.cs
@@ -1,3 +1,4 @@
+using LegoSetNotifier.AppriseApi;
 using LegoSetNotifier.RebrickableData;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -33,7 +34,7 @@ namespace LegoSetNotifier.Test
             await legoSetNotifier.SendNewSetNotificationsAsync();
 
             await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
-            await mockNotifier.DidNotReceive().SendNewSetsNotificationAsync(Arg.Any<IEnumerable<LegoSet>>());
+            await mockNotifier.DidNotReceive().SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>());
 
             await mockData.DidNotReceive().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<HashSet<string>>());
 
@@ -61,8 +62,9 @@ namespace LegoSetNotifier.Test
             mockClient.GetSetsUpdatedTime().Returns(DateTimeOffset.UtcNow);
 
             var mockNotifier = Substitute.For<INotifier>();
-            mockNotifier.SendNewSetsNotificationAsync(Arg.Any<IEnumerable<LegoSet>>()).Returns(
-                x => Task.FromResult<HashSet<string>>(x.Arg<IEnumerable<LegoSet>>().Select(a => a.ExtendedSetNumber).ToHashSet()));
+            mockNotifier.GetMaxNotificationBodyChars().Returns(AppriseApiClient.MaxBodyChars);
+            mockNotifier.GetMaxNotificationAttachments().Returns(AppriseApiClient.MaxAttachments);
+            mockNotifier.SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>()).Returns(Task.FromResult(true));
 
             var legoSetNotifier = new LegoSetNotifier(logger, mockData, mockClient, mockNotifier);
             await legoSetNotifier.DetectNewSetsAsync();
@@ -72,10 +74,9 @@ namespace LegoSetNotifier.Test
             await legoSetNotifier.SendNewSetNotificationsAsync();
 
             await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
-            await mockNotifier.Received().SendNewSetsNotificationAsync(Arg.Is<IEnumerable<LegoSet>>(l => l.Count() == 1 &&
-                l.ElementAt(0).ExtendedSetNumber.Equals(testLegoSet.ExtendedSetNumber, StringComparison.Ordinal)));
+            await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testLegoSet.ExtendedSetNumber)));
 
-            await mockData.Received().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Count == 1 && s.Contains(testLegoSet.ExtendedSetNumber)));
+            await mockData.Received().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Contains(testLegoSet.ExtendedSetNumber)));
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count());
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count());
@@ -113,7 +114,7 @@ namespace LegoSetNotifier.Test
             await legoSetNotifier.SendNewSetNotificationsAsync();
 
             await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
-            await mockNotifier.DidNotReceive().SendNewSetsNotificationAsync(Arg.Any<IEnumerable<LegoSet>>());
+            await mockNotifier.DidNotReceive().SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>());
 
             await mockData.DidNotReceive().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<HashSet<string>>());
 
@@ -171,7 +172,9 @@ namespace LegoSetNotifier.Test
             mockClient.GetSetsUpdatedTime().Returns(DateTimeOffset.UtcNow);
 
             var mockNotifier = Substitute.For<INotifier>();
-            mockNotifier.SendNewSetsNotificationAsync(Arg.Any<IEnumerable<LegoSet>>()).ThrowsAsync(new InvalidOperationException("TestException"));
+            mockNotifier.GetMaxNotificationBodyChars().Returns(AppriseApiClient.MaxBodyChars);
+            mockNotifier.GetMaxNotificationAttachments().Returns(AppriseApiClient.MaxAttachments);
+            mockNotifier.SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>()).ThrowsAsync(new InvalidOperationException("TestException"));
 
             var legoSetNotifier = new LegoSetNotifier(logger, mockData, mockClient, mockNotifier);
             await legoSetNotifier.DetectNewSetsAsync();
@@ -202,7 +205,15 @@ namespace LegoSetNotifier.Test
             {
                 new LegoSet() { ExtendedSetNumber = testPreviouslySeenLegoSets[0].ExtendedSetNumber },
                 new LegoSet() { ExtendedSetNumber = testPreviouslySeenLegoSets[1].ExtendedSetNumber },
-                new LegoSet() { ExtendedSetNumber = "34567-1" },
+                new LegoSet() { ExtendedSetNumber = "34567-1", ImageUrl = "attachment 3" },
+                new LegoSet() { ExtendedSetNumber = "45678-1", ImageUrl = "attachment 4" },
+                new LegoSet() { ExtendedSetNumber = "56789-1", ImageUrl = "attachment 5" },
+            };
+            var testNewlySeenLegoSetNumbers = new HashSet<string>()
+            {
+                testNewlySeenLegoSets[2].ExtendedSetNumber,
+                testNewlySeenLegoSets[3].ExtendedSetNumber,
+                testNewlySeenLegoSets[4].ExtendedSetNumber,
             };
 
             var logger = new TestLogger();
@@ -216,30 +227,39 @@ namespace LegoSetNotifier.Test
             mockClient.GetSetsAsync().Returns(Task.FromResult(testNewlySeenLegoSets));
             mockClient.GetSetsUpdatedTime().Returns(newSetsSeenTime);
 
-            // Simulate that the not-before-seen set's notification fails.
+            // Simulate that ONE of the not-before-seen sets' notification fails.
             var testNotificationException = new HttpRequestException("TestNotificationException");
             var mockNotifier = Substitute.For<INotifier>();
-            mockNotifier.SendNewSetsNotificationAsync(
-                Arg.Is<IEnumerable<LegoSet>>(l => l.Count() == 1 &&
-                    l.ElementAt(0).ExtendedSetNumber.Equals(testNewlySeenLegoSets[2].ExtendedSetNumber, StringComparison.Ordinal)))
+            mockNotifier.GetMaxNotificationBodyChars().Returns(AppriseApiClient.MaxBodyChars);
+            mockNotifier.GetMaxNotificationAttachments().Returns(1u); // Force newly-seen sets to batch up one at a time.
+            mockNotifier.SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[2].ExtendedSetNumber)))
+                .Returns(Task.FromResult(true));
+            mockNotifier.SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[3].ExtendedSetNumber)))
                 .ThrowsAsync(testNotificationException);
+            mockNotifier.SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[4].ExtendedSetNumber)))
+                .Returns(Task.FromResult(true));
 
             var legoSetNotifier = new LegoSetNotifier(logger, mockData, mockClient, mockNotifier);
             await legoSetNotifier.DetectNewSetsAsync();
 
             await mockData.Received().UpdateSetsAsync(Arg.Is<Dictionary<string, PreviouslySeenLegoSet>>(
-                l => l.Count == 3 &&
+                l => l.Count == 5 &&
                 l.ContainsKey(testPreviouslySeenLegoSets[0].ExtendedSetNumber) &&
                 l.ContainsKey(testPreviouslySeenLegoSets[1].ExtendedSetNumber) &&
-                l.ContainsKey(testNewlySeenLegoSets[2].ExtendedSetNumber)));
+                l.ContainsKey(testNewlySeenLegoSets[2].ExtendedSetNumber) &&
+                l.ContainsKey(testNewlySeenLegoSets[3].ExtendedSetNumber) &&
+                l.ContainsKey(testNewlySeenLegoSets[4].ExtendedSetNumber)));
 
             await legoSetNotifier.SendNewSetNotificationsAsync();
 
-            await mockNotifier.Received().SendNewSetsNotificationAsync(Arg.Is<IEnumerable<LegoSet>>(l => l.Count() == 1 &&
-                l.ElementAt(0).ExtendedSetNumber.Equals(testNewlySeenLegoSets[2].ExtendedSetNumber, StringComparison.Ordinal)));
+            await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[2].ExtendedSetNumber)));
+            await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[3].ExtendedSetNumber)));
             await mockNotifier.Received().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Is<Exception>(testNotificationException));
+            await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[4].ExtendedSetNumber)));
 
-            await mockData.DidNotReceive().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<HashSet<string>>());
+            await mockData.Received().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Contains(testNewlySeenLegoSets[2].ExtendedSetNumber)));
+            await mockData.DidNotReceive().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Contains(testNewlySeenLegoSets[3].ExtendedSetNumber)));
+            await mockData.Received().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Contains(testNewlySeenLegoSets[4].ExtendedSetNumber)));
 
             Assert.AreEqual(1, logger.GetLogs(LogLevel.Error).Count());
             Assert.IsInstanceOfType<HttpRequestException>(logger.GetLogs(LogLevel.Error)[0].Exception);

--- a/LegoSetNotifier.Test/LegoSetNotifierTests.cs
+++ b/LegoSetNotifier.Test/LegoSetNotifierTests.cs
@@ -31,7 +31,7 @@ namespace LegoSetNotifier.Test
 
             await mockData.Received().UpdateSetsAsync(Arg.Is<Dictionary<string, PreviouslySeenLegoSet>>(l => l.Count == 0));
 
-            await legoSetNotifier.SendNewSetNotificationsAsync();
+            await legoSetNotifier.SendNotificationsAsync(releaseYearForNewSets: 0);
 
             await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
             await mockNotifier.DidNotReceive().SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>());
@@ -71,52 +71,12 @@ namespace LegoSetNotifier.Test
 
             await mockData.Received().UpdateSetsAsync(Arg.Is<Dictionary<string, PreviouslySeenLegoSet>>(l => l.Count == 1 && l.ContainsKey(testLegoSet.ExtendedSetNumber)));
 
-            await legoSetNotifier.SendNewSetNotificationsAsync();
+            await legoSetNotifier.SendNotificationsAsync(releaseYearForNewSets: 0);
 
             await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
             await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testLegoSet.ExtendedSetNumber)));
 
             await mockData.Received().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Is<HashSet<string>>(s => s.Contains(testLegoSet.ExtendedSetNumber)));
-
-            Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count());
-            Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count());
-        }
-
-        [TestMethod]
-        public async Task TestNewNonPurchaseableSetNoNotificationAsync()
-        {
-            var testLegoSet = new LegoSet()
-            {
-                // Indicate the set is non-purchaseable with a set number > 5 digits.
-                ExtendedSetNumber = "1234567890-1",
-            };
-
-            Assert.IsFalse(testLegoSet.IsPurchaseableSet());
-
-            var logger = new TestLogger();
-
-            var testLastUpdatedTime = DateTimeOffset.UtcNow - TimeSpan.FromHours(1);
-            var mockData = Substitute.For<IPreviouslySeenData>();
-            mockData.GetDataSourceName().Returns("MockData");
-            mockData.GetSetsAsync().Returns(Task.FromResult(new Dictionary<string, PreviouslySeenLegoSet>()));
-
-            var mockClient = Substitute.For<IRebrickableDataClient>();
-            mockClient.GetSetsAsync().Returns(Task.FromResult(new List<LegoSet>() { testLegoSet }));
-            mockClient.GetSetsUpdatedTime().Returns(DateTimeOffset.UtcNow);
-
-            var mockNotifier = Substitute.For<INotifier>();
-
-            var legoSetNotifier = new LegoSetNotifier(logger, mockData, mockClient, mockNotifier);
-            await legoSetNotifier.DetectNewSetsAsync();
-
-            await mockData.Received().UpdateSetsAsync(Arg.Is<Dictionary<string, PreviouslySeenLegoSet>>(l => l.Count == 1 && l.ContainsKey(testLegoSet.ExtendedSetNumber)));
-
-            await legoSetNotifier.SendNewSetNotificationsAsync();
-
-            await mockNotifier.DidNotReceive().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Any<Exception?>());
-            await mockNotifier.DidNotReceive().SendLegoSetBatchNotificationAsync(Arg.Any<LegoSetBatchNotification>());
-
-            await mockData.DidNotReceive().MarkSetsAsNotifiedAsync(Arg.Any<DateTimeOffset>(), Arg.Any<HashSet<string>>());
 
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Warning).Count());
             Assert.AreEqual(0, logger.GetLogs(LogLevel.Error).Count());
@@ -181,7 +141,7 @@ namespace LegoSetNotifier.Test
 
             await mockData.Received().UpdateSetsAsync(Arg.Is<Dictionary<string, PreviouslySeenLegoSet>>(l => l.Count == 1 && l.ContainsKey(testLegoSet.ExtendedSetNumber)));
 
-            await legoSetNotifier.SendNewSetNotificationsAsync();
+            await legoSetNotifier.SendNotificationsAsync(releaseYearForNewSets: 0);
 
             Assert.IsInstanceOfType<InvalidOperationException>(logger.GetLogs(LogLevel.Error)[0].Exception);
             await mockNotifier.Received().SendErrorNotificationAsync(Arg.Any<string>(), Arg.Is<Exception?>(ex => ex != null && ex.Message.Equals("TestException", StringComparison.Ordinal)));
@@ -250,7 +210,7 @@ namespace LegoSetNotifier.Test
                 l.ContainsKey(testNewlySeenLegoSets[3].ExtendedSetNumber) &&
                 l.ContainsKey(testNewlySeenLegoSets[4].ExtendedSetNumber)));
 
-            await legoSetNotifier.SendNewSetNotificationsAsync();
+            await legoSetNotifier.SendNotificationsAsync(releaseYearForNewSets: 0);
 
             await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[2].ExtendedSetNumber)));
             await mockNotifier.Received().SendLegoSetBatchNotificationAsync(Arg.Is<LegoSetBatchNotification>(n => n.GetLegoSetNumbers().Contains(testNewlySeenLegoSets[3].ExtendedSetNumber)));

--- a/LegoSetNotifier/AppriseApi/AppriseApiClient.cs
+++ b/LegoSetNotifier/AppriseApi/AppriseApiClient.cs
@@ -5,6 +5,14 @@ namespace LegoSetNotifier.AppriseApi
 {
     public class AppriseApiClient : IAppriseApiClient, IDisposable
     {
+        // Apprise email notifications have a body size limit of 32k characters.
+        // Source: https://appriseit.com/services/email/
+        public const uint MaxBodyChars = 32768;
+
+        // NOTE: The APPRISE_MAX_ATTACHMENTS setting is configurable by an Apprise API service.
+        // This implementation assumes the target service uses a default initial setting value.
+        public const uint MaxAttachments = 6;
+
         private readonly string baseUrl;
 
         private HttpClient httpClient;

--- a/LegoSetNotifier/AppriseNotifier.cs
+++ b/LegoSetNotifier/AppriseNotifier.cs
@@ -57,7 +57,7 @@ namespace LegoSetNotifier
 
         public async Task<bool> SendLegoSetBatchNotificationAsync(LegoSetBatchNotification notification)
         {
-            var notificationContent = notification.GetContent();
+            var notificationContent = notification.GetNotificationContent();
             try
             {
                 return await this.SendThrottledNotificationAsync(notificationContent);

--- a/LegoSetNotifier/AppriseNotifier.cs
+++ b/LegoSetNotifier/AppriseNotifier.cs
@@ -11,14 +11,6 @@ namespace LegoSetNotifier
 {
     public class AppriseNotifier : INotifier
     {
-        // Apprise email notifications have a body size limit of 32k characters.
-        // Source: https://appriseit.com/services/email/
-        public const uint MaxBodyChars = 32768;
-
-        // NOTE: The APPRISE_MAX_ATTACHMENTS setting is configurable by an Apprise API service.
-        // This implementation assumes the target service uses a default initial setting value.
-        public const uint MaxAttachments = 6;
-
         // This implementation ASSUMES notifications will be sent to a Gmail inbox.
         // Gmail limits a recipient to receiving at most 60 messages per minute.
         // Source: https://support.google.com/a/answer/1366776
@@ -41,6 +33,16 @@ namespace LegoSetNotifier
             this.notifyKey = notifyKey;
         }
 
+        public uint GetMaxNotificationBodyChars()
+        {
+            return AppriseApiClient.MaxBodyChars;
+        }
+
+        public uint GetMaxNotificationAttachments()
+        {
+            return AppriseApiClient.MaxAttachments;
+        }
+
         public async Task<bool> SendErrorNotificationAsync(string message, Exception? ex)
         {
             var notification = new AppriseApiNotifyContent()
@@ -53,87 +55,34 @@ namespace LegoSetNotifier
             return await this.SendThrottledNotificationAsync(notification);
         }
 
-        public async Task<HashSet<string>> SendNewSetsNotificationAsync(IEnumerable<RebrickableData.LegoSet> legoSets)
+        public async Task<bool> SendLegoSetBatchNotificationAsync(LegoSetBatchNotification notification)
         {
-            var successfullyNotifiedSetNumbers = new HashSet<string>();
-
-            // Build notifications out of sets in batches, each batch within the maximum size of a notification body.
-            var notificationSetNumbers = new HashSet<string>();
-            var notificationBodyBuilder = new StringBuilder();
-            var notificationAttachments = new List<string>();
-            foreach (var legoSet in legoSets)
-            {
-                var legoSetBodyContent = $"\n- {legoSet.ExtendedSetNumber} {legoSet.Name} -- [Rebrickable]({legoSet.GetRebrickableUrl()}), [LEGO Shop]({legoSet.GetLegoShopUrl()})";
-                if (legoSetBodyContent.Length >= MaxBodyChars)
-                {
-                    await this.SendErrorNotificationAsync($"Notification for set {legoSet.ExtendedSetNumber} cannot be sent, body size {legoSetBodyContent.Length} exceeds maximum {MaxBodyChars}", null);
-
-                    // Assume that this is as good of a notification as this set is ever gonna get.
-                    successfullyNotifiedSetNumbers.Add(legoSet.ExtendedSetNumber);
-                    continue;
-                }
-                else if (
-                    ((notificationBodyBuilder.Length + legoSetBodyContent.Length) >= MaxBodyChars) ||
-                    (!string.IsNullOrEmpty(legoSet.ImageUrl) && (notificationAttachments.Count == MaxAttachments)))
-                {
-                    // This can't be added to the current batch; flush that batch, and start building a new one.
-                    var batchSuccess = await this.SendBatchedSetsNotificationAsync(notificationSetNumbers, notificationBodyBuilder, notificationAttachments);
-                    if (batchSuccess)
-                    {
-                        successfullyNotifiedSetNumbers.UnionWith(notificationSetNumbers);
-                    }
-
-                    // Reset the currently-building notification state.
-                    notificationSetNumbers.Clear();
-                    notificationBodyBuilder.Clear();
-                    notificationAttachments.Clear();
-                }
-
-                notificationSetNumbers.Add(legoSet.ExtendedSetNumber);
-                notificationBodyBuilder.Append(legoSetBodyContent);
-                if (!string.IsNullOrEmpty(legoSet.ImageUrl))
-                {
-                    notificationAttachments.Add(legoSet.ImageUrl);
-                }
-            }
-
-            if (notificationSetNumbers.Count > 0)
-            {
-                var batchSuccess = await this.SendBatchedSetsNotificationAsync(notificationSetNumbers, notificationBodyBuilder, notificationAttachments);
-                if (batchSuccess)
-                {
-                    successfullyNotifiedSetNumbers.UnionWith(notificationSetNumbers);
-                }
-            }
-
-            return successfullyNotifiedSetNumbers;
-        }
-
-        private async Task<bool> SendBatchedSetsNotificationAsync(HashSet<string> setNumbers, StringBuilder bodyBuilder, List<string> attachments)
-        {
-            var notification = new AppriseApiNotifyContent()
-            {
-                Title = $"{setNumbers.Count} new LEGO sets",
-                Format = "markdown",
-                Body = bodyBuilder.ToString(),
-                Attachments = attachments,
-            };
-
+            var notificationContent = notification.GetContent();
             try
             {
-                return await this.SendThrottledNotificationAsync(notification);
+                return await this.SendThrottledNotificationAsync(notificationContent);
             }
             catch (AppriseApiException ex) when (ex.ErrorMessage.Equals("Bad Attachment", StringComparison.Ordinal))
             {
                 // A very special case: if the notification failed due to "Bad Attachment" then retry without attachments.
-                notification.Body += "\n\nA bad-attachment error was encountered for one or more attachments:";
-                foreach (var attachment in notification.Attachments)
+                // But FIRST, send an error notification to indicate this failure.
+                var setNumbersString = string.Join(", ", notification.GetLegoSetNumbers());
+                var attachmentErrorNotification = new AppriseApiNotifyContent()
                 {
-                    notification.Body += $"\n- {attachment}";
+                    Type = "failure",
+                    Title = $"Lego Set Batch Notification error: Bad Attachment(s)",
+                    Body = $"Error {ex.ErrorMessage} from Apprise API, will retry with attachments stripped.\n\n",
+                };
+                foreach (var attachment in notificationContent.Attachments)
+                {
+                    attachmentErrorNotification.Body += $"\n- {attachment}";
                 }
+                attachmentErrorNotification.Body += $"Affected set numbers: {setNumbersString}\n\n{ex}\n\n";
+                await this.SendThrottledNotificationAsync(attachmentErrorNotification);
 
-                notification.Attachments.Clear();
-                return await this.SendThrottledNotificationAsync(notification);
+                // Now, retry the original notification without attachments.
+                notificationContent.Attachments.Clear();
+                return await this.SendThrottledNotificationAsync(notificationContent);
             }
         }
 

--- a/LegoSetNotifier/INotifier.cs
+++ b/LegoSetNotifier/INotifier.cs
@@ -2,8 +2,12 @@
 {
     public interface INotifier
     {
+        public uint GetMaxNotificationBodyChars();
+
+        public uint GetMaxNotificationAttachments();
+
         public Task<bool> SendErrorNotificationAsync(string message, Exception? ex);
 
-        public Task<HashSet<string>> SendNewSetsNotificationAsync(IEnumerable<RebrickableData.LegoSet> legoSets);
+        public Task<bool> SendLegoSetBatchNotificationAsync(LegoSetBatchNotification notification);
     }
 }

--- a/LegoSetNotifier/IPreviouslySeenData.cs
+++ b/LegoSetNotifier/IPreviouslySeenData.cs
@@ -8,6 +8,6 @@
 
         public Task UpdateSetsAsync(Dictionary<string, PreviouslySeenLegoSet> legoSets);
 
-        public Task MarkSetsAsNotifiedAsync(DateTimeOffset notifiedAtTime, HashSet<string> legoSetNumbers);
+        public Task MarkSetsAsNotifiedAsync(DateTimeOffset notifiedAtTime, ISet<string> legoSetNumbers);
     }
 }

--- a/LegoSetNotifier/LegoSetBatchNotification.cs
+++ b/LegoSetNotifier/LegoSetBatchNotification.cs
@@ -5,6 +5,24 @@ namespace LegoSetNotifier
 {
     public class LegoSetBatchNotification
     {
+        public class NotificationSettings
+        {
+            public required string Label { get; set; }
+            public required bool IncludeAttachments { get; set; }
+        }
+
+        public static readonly NotificationSettings NewLegoSetNotificationSettings = new NotificationSettings()
+        {
+            Label = "New Lego Sets",
+            IncludeAttachments = true,
+        };
+
+        public static readonly NotificationSettings NonPurchaseableLegoSetNotificationSettings = new NotificationSettings()
+        {
+            Label = "Non-Purchaseable Lego Sets",
+            IncludeAttachments = false,
+        };
+
         class BatchContext
         {
             public required uint FirstLegoSetIndex;
@@ -39,13 +57,13 @@ namespace LegoSetNotifier
         // Default constructor for testing with NSubstitute; outside of tests, this object will be invalid!
         public LegoSetBatchNotification() { }
 
-        private LegoSetBatchNotification(BatchContext context, StringBuilder bodyBuilder, List<string> attachments)
+        private LegoSetBatchNotification(NotificationSettings settings, BatchContext context, StringBuilder bodyBuilder, List<string> attachments)
         {
             this.Context = context;
 
             this.NotificationContent = new AppriseApiNotifyContent()
             {
-                Title = $"Lego Set Notifier: {this.Context.LegoSetNumbers.Count} new LEGO sets",
+                Title = $"Lego Set Notifier: {this.Context.LegoSetNumbers.Count} {settings.Label}",
                 Format = "markdown",
                 Body = bodyBuilder.ToString(),
                 Attachments = attachments,
@@ -58,7 +76,7 @@ namespace LegoSetNotifier
             }
         }
 
-        public static IEnumerable<LegoSetBatchNotification> BuildNotifications(INotifier notifier, IEnumerable<RebrickableData.LegoSet> legoSets)
+        public static IEnumerable<LegoSetBatchNotification> BuildNotifications(INotifier notifier, NotificationSettings settings, IEnumerable<RebrickableData.LegoSet> legoSets)
         {
             var maxBodyChars = notifier.GetMaxNotificationBodyChars();
             var maxAttachments = notifier.GetMaxNotificationAttachments();
@@ -101,10 +119,10 @@ namespace LegoSetNotifier
 
                 if (
                     ((batchBodyBuilder.Length + legoSetBodyContent.Length) >= maxBodyChars) ||
-                    (!string.IsNullOrEmpty(legoSet.ImageUrl) && (batchAttachments.Count == maxAttachments)))
+                    (settings.IncludeAttachments && !string.IsNullOrEmpty(legoSet.ImageUrl) && (batchAttachments.Count == maxAttachments)))
                 {
                     // This can't be added to the current batch; flush that batch, and start building a new one.
-                    batches.Add(new LegoSetBatchNotification(batchContext, batchBodyBuilder, batchAttachments));
+                    batches.Add(new LegoSetBatchNotification(settings, batchContext, batchBodyBuilder, batchAttachments));
 
                     // Reset the currently-building batch state.
                     batchContext = new BatchContext()
@@ -121,7 +139,7 @@ namespace LegoSetNotifier
                 batchContext.LastLegoSetIndex = legoSetIndex;
                 batchContext.LegoSetNumbers.Add(legoSet.ExtendedSetNumber);
                 batchBodyBuilder.Append(legoSetBodyContent);
-                if (!string.IsNullOrEmpty(legoSet.ImageUrl))
+                if (settings.IncludeAttachments && !string.IsNullOrEmpty(legoSet.ImageUrl))
                 {
                     batchAttachments.Add(legoSet.ImageUrl);
                 }
@@ -131,7 +149,7 @@ namespace LegoSetNotifier
 
             if (batchContext.LegoSetNumbers.Count > 0)
             {
-                batches.Add(new LegoSetBatchNotification(batchContext, batchBodyBuilder, batchAttachments));
+                batches.Add(new LegoSetBatchNotification(settings, batchContext, batchBodyBuilder, batchAttachments));
             }
 
             return batches;

--- a/LegoSetNotifier/LegoSetBatchNotification.cs
+++ b/LegoSetNotifier/LegoSetBatchNotification.cs
@@ -8,20 +8,39 @@ namespace LegoSetNotifier
         public class NotificationSettings
         {
             public required string Label { get; set; }
+            public required bool IncludeLegoSetDetails { get; set; }
             public required bool IncludeAttachments { get; set; }
         }
 
-        public static readonly NotificationSettings NewLegoSetNotificationSettings = new NotificationSettings()
+        public static NotificationSettings FullDetailSettings(string notificationLabel)
         {
-            Label = "New Lego Sets",
-            IncludeAttachments = true,
-        };
+            return new NotificationSettings()
+            {
+                Label = notificationLabel,
+                IncludeLegoSetDetails = true,
+                IncludeAttachments = true,
+            };
+        }
 
-        public static readonly NotificationSettings NonPurchaseableLegoSetNotificationSettings = new NotificationSettings()
+        public static NotificationSettings DigestSettings(string notificationLabel)
         {
-            Label = "Non-Purchaseable Lego Sets",
-            IncludeAttachments = false,
-        };
+            return new NotificationSettings()
+            {
+                Label = notificationLabel,
+                IncludeLegoSetDetails = true,
+                IncludeAttachments = false,
+            };
+        }
+
+        public static NotificationSettings SummaryOnlySettings(string notificationLabel)
+        {
+            return new NotificationSettings()
+            {
+                Label = notificationLabel,
+                IncludeLegoSetDetails = false,
+                IncludeAttachments = false,
+            };
+        }
 
         class BatchContext
         {
@@ -78,9 +97,34 @@ namespace LegoSetNotifier
 
         public static IEnumerable<LegoSetBatchNotification> BuildNotifications(INotifier notifier, NotificationSettings settings, IEnumerable<RebrickableData.LegoSet> legoSets)
         {
+            var totalCount = (uint)legoSets.Count();
+
+            if (!settings.IncludeLegoSetDetails)
+            {
+                // Shortcut the batching process, and just create a simple summary.
+                var legoSetsList = legoSets.ToList();
+
+                var summaryContext = new BatchContext()
+                {
+                    FirstLegoSetIndex = 0,
+                    LastLegoSetIndex = totalCount - 1,
+                    TotalLegoSetCount = totalCount,
+                    LegoSetNumbers = legoSetsList.Select(s => s.ExtendedSetNumber).ToHashSet(),
+                };
+
+                var purchaseableCount = legoSetsList.Where(s => s.IsPurchaseableSet()).Count();
+                var nonPurchaseableCount = totalCount - purchaseableCount;
+                var summaryBody = $"Summary: {purchaseableCount} purchaseable sets, {nonPurchaseableCount} non-purchaseable sets";
+                var summaryBuilder = new StringBuilder(summaryBody);
+
+                return new List<LegoSetBatchNotification>()
+                {
+                    new LegoSetBatchNotification(settings, summaryContext, summaryBuilder, new List<string>())
+                };
+            }
+
             var maxBodyChars = notifier.GetMaxNotificationBodyChars();
             var maxAttachments = notifier.GetMaxNotificationAttachments();
-            var totalCount = (uint)legoSets.Count();
             var batches = new List<LegoSetBatchNotification>();
 
             // Build notifications out of sets in batches, each batch within the maximum size of a notification body.
@@ -97,7 +141,7 @@ namespace LegoSetNotifier
             var legoSetIndex = 0u;
             foreach (var legoSet in legoSets)
             {
-                var legoSetBodyContent = $"- {legoSet.ExtendedSetNumber} {legoSet.Name} ({legoSet.ReleaseYear}) {legoSet.NumberOfParts} pcs -- [Rebrickable]({legoSet.GetRebrickableUrl()})";
+                var legoSetBodyContent = $"- {legoSet.ExtendedSetNumber} {legoSet.Name} ({legoSet.ReleaseYear}) -- [Rebrickable]({legoSet.GetRebrickableUrl()})";
                 if (legoSet.IsPurchaseableSet())
                 {
                     legoSetBodyContent += $", [LEGO Shop]({legoSet.GetLegoShopUrl()})";

--- a/LegoSetNotifier/LegoSetBatchNotification.cs
+++ b/LegoSetNotifier/LegoSetBatchNotification.cs
@@ -1,0 +1,103 @@
+﻿using LegoSetNotifier.AppriseApi;
+using System.Text;
+
+namespace LegoSetNotifier
+{
+    public class LegoSetBatchNotification
+    {
+        private AppriseApiNotifyContent? Content = null;
+        private HashSet<string> LegoSetNumbers = new HashSet<string>();
+
+        public virtual AppriseApiNotifyContent GetContent()
+        {
+            if (this.Content == null)
+            {
+                throw new InvalidDataException("Notification content was null");
+            }
+
+            return this.Content;
+        }
+
+        public virtual ISet<string> GetLegoSetNumbers()
+        {
+            return this.LegoSetNumbers;
+        }
+
+        // Default constructor for testing with NSubstitute; outside of tests, this object will be invalid!
+        public LegoSetBatchNotification() { }
+
+        private LegoSetBatchNotification(HashSet<string> legoSetNumbers, StringBuilder bodyBuilder, List<string> attachments)
+        {
+            this.Content = new AppriseApiNotifyContent()
+            {
+                Title = $"{legoSetNumbers.Count} new LEGO sets",
+                Format = "markdown",
+                Body = bodyBuilder.ToString(),
+                Attachments = attachments,
+            };
+
+            this.LegoSetNumbers = legoSetNumbers;
+        }
+
+        public static IEnumerable<LegoSetBatchNotification> BuildNotifications(INotifier notifier, IEnumerable<RebrickableData.LegoSet> legoSets)
+        {
+            var maxBodyChars = notifier.GetMaxNotificationBodyChars();
+            var maxAttachments = notifier.GetMaxNotificationAttachments();
+            var batches = new List<LegoSetBatchNotification>();
+
+            // Build notifications out of sets in batches, each batch within the maximum size of a notification body.
+            var batchSetNumbers = new HashSet<string>();
+            var batchBodyBuilder = new StringBuilder();
+            var batchAttachments = new List<string>();
+            foreach (var legoSet in legoSets)
+            {
+                var legoSetBodyContent = $"- {legoSet.ExtendedSetNumber} {legoSet.Name} ({legoSet.ReleaseYear}) {legoSet.NumberOfParts} pcs -- [Rebrickable]({legoSet.GetRebrickableUrl()})";
+                if (legoSet.IsPurchaseableSet())
+                {
+                    legoSetBodyContent += $", [LEGO Shop]({legoSet.GetLegoShopUrl()})";
+                }
+                legoSetBodyContent += "\n";
+
+                if (legoSetBodyContent.Length >= maxBodyChars)
+                {
+                    // Try a simpler format, as a fallback.
+                    legoSetBodyContent = $"- {legoSet.ExtendedSetNumber} (content exceeded max {maxBodyChars}) -- [Rebrickable]({legoSet.GetRebrickableUrl()})\n";
+
+                    // If even this fallback exceeds the maximum size of a batch, then assume the size constraint is unworkable.
+                    // NOTE: This will break the caller's batching attempt, beyond repair.
+                    if (legoSetBodyContent.Length >= maxBodyChars)
+                    {
+                        throw new InvalidDataException($"Notification content for set {legoSet.ExtendedSetNumber} exceeds notifier's max body size {maxBodyChars}");
+                    }
+                }
+
+                if (
+                    ((batchBodyBuilder.Length + legoSetBodyContent.Length) >= maxBodyChars) ||
+                    (!string.IsNullOrEmpty(legoSet.ImageUrl) && (batchAttachments.Count == maxAttachments)))
+                {
+                    // This can't be added to the current batch; flush that batch, and start building a new one.
+                    batches.Add(new LegoSetBatchNotification(batchSetNumbers, batchBodyBuilder, batchAttachments));
+
+                    // Reset the currently-building batch state.
+                    batchSetNumbers = new HashSet<string>();
+                    batchBodyBuilder = new StringBuilder();
+                    batchAttachments = new List<string>();
+                }
+
+                batchSetNumbers.Add(legoSet.ExtendedSetNumber);
+                batchBodyBuilder.Append(legoSetBodyContent);
+                if (!string.IsNullOrEmpty(legoSet.ImageUrl))
+                {
+                    batchAttachments.Add(legoSet.ImageUrl);
+                }
+            }
+
+            if (batchSetNumbers.Count > 0)
+            {
+                batches.Add(new LegoSetBatchNotification(batchSetNumbers, batchBodyBuilder, batchAttachments));
+            }
+
+            return batches;
+        }
+    }
+}

--- a/LegoSetNotifier/LegoSetBatchNotification.cs
+++ b/LegoSetNotifier/LegoSetBatchNotification.cs
@@ -5,50 +5,78 @@ namespace LegoSetNotifier
 {
     public class LegoSetBatchNotification
     {
-        private AppriseApiNotifyContent? Content = null;
-        private HashSet<string> LegoSetNumbers = new HashSet<string>();
-
-        public virtual AppriseApiNotifyContent GetContent()
+        class BatchContext
         {
-            if (this.Content == null)
+            public required uint FirstLegoSetIndex;
+            public required uint LastLegoSetIndex;
+            public required uint TotalLegoSetCount;
+            public required HashSet<string> LegoSetNumbers;
+        }
+
+        private BatchContext? Context = null;
+        private AppriseApiNotifyContent? NotificationContent = null;
+
+        public virtual AppriseApiNotifyContent GetNotificationContent()
+        {
+            if (this.NotificationContent == null)
             {
                 throw new InvalidDataException("Notification content was null");
             }
 
-            return this.Content;
+            return this.NotificationContent;
         }
 
         public virtual ISet<string> GetLegoSetNumbers()
         {
-            return this.LegoSetNumbers;
+            if (this.Context == null)
+            {
+                throw new InvalidDataException("Batch context was null");
+            }
+
+            return this.Context.LegoSetNumbers;
         }
 
         // Default constructor for testing with NSubstitute; outside of tests, this object will be invalid!
         public LegoSetBatchNotification() { }
 
-        private LegoSetBatchNotification(HashSet<string> legoSetNumbers, StringBuilder bodyBuilder, List<string> attachments)
+        private LegoSetBatchNotification(BatchContext context, StringBuilder bodyBuilder, List<string> attachments)
         {
-            this.Content = new AppriseApiNotifyContent()
+            this.Context = context;
+
+            this.NotificationContent = new AppriseApiNotifyContent()
             {
-                Title = $"{legoSetNumbers.Count} new LEGO sets",
+                Title = $"Lego Set Notifier: {this.Context.LegoSetNumbers.Count} new LEGO sets",
                 Format = "markdown",
                 Body = bodyBuilder.ToString(),
                 Attachments = attachments,
             };
 
-            this.LegoSetNumbers = legoSetNumbers;
+            // If context indicates there are multiple pages/batches, include a pagination description in the title.
+            if (this.Context.LegoSetNumbers.Count != this.Context.TotalLegoSetCount)
+            {
+                this.NotificationContent.Title += $" ({this.Context.FirstLegoSetIndex + 1} - {this.Context.LastLegoSetIndex + 1} of {this.Context.TotalLegoSetCount})";
+            }
         }
 
         public static IEnumerable<LegoSetBatchNotification> BuildNotifications(INotifier notifier, IEnumerable<RebrickableData.LegoSet> legoSets)
         {
             var maxBodyChars = notifier.GetMaxNotificationBodyChars();
             var maxAttachments = notifier.GetMaxNotificationAttachments();
+            var totalCount = (uint)legoSets.Count();
             var batches = new List<LegoSetBatchNotification>();
 
             // Build notifications out of sets in batches, each batch within the maximum size of a notification body.
-            var batchSetNumbers = new HashSet<string>();
+            var batchContext = new BatchContext()
+            {
+                FirstLegoSetIndex = 0,
+                LastLegoSetIndex = 0,
+                TotalLegoSetCount = totalCount,
+                LegoSetNumbers = new HashSet<string>(),
+            };
             var batchBodyBuilder = new StringBuilder();
             var batchAttachments = new List<string>();
+
+            var legoSetIndex = 0u;
             foreach (var legoSet in legoSets)
             {
                 var legoSetBodyContent = $"- {legoSet.ExtendedSetNumber} {legoSet.Name} ({legoSet.ReleaseYear}) {legoSet.NumberOfParts} pcs -- [Rebrickable]({legoSet.GetRebrickableUrl()})";
@@ -76,25 +104,34 @@ namespace LegoSetNotifier
                     (!string.IsNullOrEmpty(legoSet.ImageUrl) && (batchAttachments.Count == maxAttachments)))
                 {
                     // This can't be added to the current batch; flush that batch, and start building a new one.
-                    batches.Add(new LegoSetBatchNotification(batchSetNumbers, batchBodyBuilder, batchAttachments));
+                    batches.Add(new LegoSetBatchNotification(batchContext, batchBodyBuilder, batchAttachments));
 
                     // Reset the currently-building batch state.
-                    batchSetNumbers = new HashSet<string>();
+                    batchContext = new BatchContext()
+                    {
+                        FirstLegoSetIndex = legoSetIndex,
+                        LastLegoSetIndex = legoSetIndex,
+                        TotalLegoSetCount = totalCount,
+                        LegoSetNumbers = new HashSet<string>(),
+                    };
                     batchBodyBuilder = new StringBuilder();
                     batchAttachments = new List<string>();
                 }
 
-                batchSetNumbers.Add(legoSet.ExtendedSetNumber);
+                batchContext.LastLegoSetIndex = legoSetIndex;
+                batchContext.LegoSetNumbers.Add(legoSet.ExtendedSetNumber);
                 batchBodyBuilder.Append(legoSetBodyContent);
                 if (!string.IsNullOrEmpty(legoSet.ImageUrl))
                 {
                     batchAttachments.Add(legoSet.ImageUrl);
                 }
+
+                ++legoSetIndex;
             }
 
-            if (batchSetNumbers.Count > 0)
+            if (batchContext.LegoSetNumbers.Count > 0)
             {
-                batches.Add(new LegoSetBatchNotification(batchSetNumbers, batchBodyBuilder, batchAttachments));
+                batches.Add(new LegoSetBatchNotification(batchContext, batchBodyBuilder, batchAttachments));
             }
 
             return batches;

--- a/LegoSetNotifier/LegoSetNotifier.cs
+++ b/LegoSetNotifier/LegoSetNotifier.cs
@@ -10,6 +10,8 @@ namespace LegoSetNotifier
         private readonly IRebrickableDataClient dataClient;
         private readonly INotifier? notifier;
 
+        private bool isInitializingSeenData = false;
+
         public LegoSetNotifier(
             ILogger logger,
             IPreviouslySeenData seenData,
@@ -33,6 +35,11 @@ namespace LegoSetNotifier
             }
 
             var seenSets = await this.seenData.GetSetsAsync();
+            if (seenSets.Count == 0)
+            {
+                this.logger.LogInformation("Seen data is empty, will initialize it with from-scratch notification settings");
+                this.isInitializingSeenData = true;
+            }
 
             var newSetsCount = 0;
             foreach (var extendedSetNumber in liveDataSets.Keys)
@@ -77,21 +84,39 @@ namespace LegoSetNotifier
                 return;
             }
 
-            var oldPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear < releaseYearForNewSets && s.IsPurchaseableSet());
-            await this.BuildAndSendLegoSetNotificationsAsync(
-                new LegoSetBatchNotification.NotificationSettings() { Label = "Old Purchaseable Sets", IncludeAttachments = false },
-                oldPurchaseableSets);
-
-            var oldNonPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear < releaseYearForNewSets && !s.IsPurchaseableSet());
-            await this.BuildAndSendLegoSetNotificationsAsync(
-                new LegoSetBatchNotification.NotificationSettings() { Label = "Old Non-Purchaseable Sets", IncludeAttachments = false },
-                oldNonPurchaseableSets);
-
+            var oldOrNonPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear < releaseYearForNewSets || !s.IsPurchaseableSet());
             var newPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear >= releaseYearForNewSets && s.IsPurchaseableSet());
-            await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NewLegoSetNotificationSettings, newPurchaseableSets);
 
-            var newNonPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear >= releaseYearForNewSets && !s.IsPurchaseableSet());
-            await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NonPurchaseableLegoSetNotificationSettings, newNonPurchaseableSets);
+            if (this.isInitializingSeenData)
+            {
+                // Older sets, and newer non-purchaseable sets, should be notified in a simple summary.
+                // Newer and purchaseable sets will be collected in digest notifications.
+
+                if (oldOrNonPurchaseableSets.Any())
+                {
+                    await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.SummaryOnlySettings("Old or Non-Purchaseable Sets (Initialization Summary)"), oldOrNonPurchaseableSets);
+                }
+
+                if (newPurchaseableSets.Any())
+                {
+                    await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.DigestSettings($"New Sets (Initialization Digest)"), newPurchaseableSets);
+                }
+            }
+            else
+            {
+                // Older sets, and newer non-purchaseable sets, should be notified in limited digests.
+                // Newer and purchaseable sets will be included in full-detail notifications with image attachments.
+
+                if (oldOrNonPurchaseableSets.Any())
+                {
+                    await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.DigestSettings("Old or Non-Purchaseable Sets"), oldOrNonPurchaseableSets);
+                }
+
+                if (newPurchaseableSets.Any())
+                {
+                    await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.FullDetailSettings("New Sets"), newPurchaseableSets);
+                }
+            }
         }
 
         private async Task BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NotificationSettings settings, IEnumerable<RebrickableData.LegoSet> legoSets)

--- a/LegoSetNotifier/LegoSetNotifier.cs
+++ b/LegoSetNotifier/LegoSetNotifier.cs
@@ -77,32 +77,36 @@ namespace LegoSetNotifier
                 return;
             }
 
-            try
+            var notifications = LegoSetBatchNotification.BuildNotifications(this.notifier, notYetNotifiedSets);
+            foreach (var notification in notifications)
             {
-                var notifiedAtTime = DateTimeOffset.UtcNow;
-                var notifiedSetNumbers = await this.notifier.SendNewSetsNotificationAsync(notYetNotifiedSets);
-                if (notifiedSetNumbers.Any())
+                try
                 {
-                    await this.seenData.MarkSetsAsNotifiedAsync(notifiedAtTime, notifiedSetNumbers);
+                    var notificationSuccess = await this.notifier.SendLegoSetBatchNotificationAsync(notification);
+                    if (notificationSuccess)
+                    {
+                        var notifiedAtTime = DateTimeOffset.UtcNow;
+                        var notifiedSetNumbers = notification.GetLegoSetNumbers();
+                        await this.seenData.MarkSetsAsNotifiedAsync(notifiedAtTime, notifiedSetNumbers);
 
-                    this.logger.LogInformation(
-                        "Sent notification(s) of {NumberOfNotifiedSets} new sets as of {NotifiedAtTime}",
+                        this.logger.LogInformation(
+                            "Sent notification(s) of {NumberOfNotifiedSets} new sets as of {NotifiedAtTime}",
                             notifiedSetNumbers.Count,
                             notifiedAtTime);
+                    }
+                    else
+                    {
+                        this.logger.LogError(
+                            "Failed to send notification(s) for {NumberOfNotYetNotifiedSets} new sets",
+                            notYetNotifiedSets.Count());
+                    }
                 }
-                else
+                catch (Exception ex)
                 {
-                    this.logger.LogError(
-                        "Failed to send notification(s) for {NumberOfNotYetNotifiedSets} new sets as of {NotifiedAtTime}",
-                            notYetNotifiedSets.Count(),
-                            notifiedAtTime);
+                    const string exceptionErrorMessage = "Exception sending notification(s) of new sets";
+                    this.logger.LogError(ex, exceptionErrorMessage);
+                    await notifier.SendErrorNotificationAsync($"An exception occurred while attempting to send notification(s) of {notYetNotifiedSets.Count()} new sets", ex);
                 }
-            }
-            catch (Exception ex)
-            {
-                const string exceptionErrorMessage = "Exception sending notification(s) of new sets";
-                this.logger.LogError(ex, exceptionErrorMessage);
-                await notifier.SendErrorNotificationAsync($"An exception occurred while attempting to send notification(s) of {notYetNotifiedSets.Count()} new sets", ex);
             }
         }
     }

--- a/LegoSetNotifier/LegoSetNotifier.cs
+++ b/LegoSetNotifier/LegoSetNotifier.cs
@@ -63,7 +63,7 @@ namespace LegoSetNotifier
             await this.seenData.UpdateSetsAsync(seenSets);
         }
 
-        public async Task SendNewSetNotificationsAsync()
+        public async Task SendNotificationsAsync(int releaseYearForNewSets)
         {
             if (this.notifier == null)
             {
@@ -71,14 +71,38 @@ namespace LegoSetNotifier
             }
 
             var seenSets = await this.seenData.GetSetsAsync();
-            var notYetNotifiedSets = seenSets.Select(p => p.Value).Where(s => s.IsPurchaseableSet() && s.NotifiedAtTime == null);
+            var notYetNotifiedSets = seenSets.Select(p => p.Value).Where(s => s.NotifiedAtTime == null);
             if (!notYetNotifiedSets.Any())
             {
                 return;
             }
 
-            var notifications = LegoSetBatchNotification.BuildNotifications(this.notifier, notYetNotifiedSets);
-            foreach (var notification in notifications)
+            var oldPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear < releaseYearForNewSets && s.IsPurchaseableSet());
+            await this.BuildAndSendLegoSetNotificationsAsync(
+                new LegoSetBatchNotification.NotificationSettings() { Label = "Old Purchaseable Sets", IncludeAttachments = false },
+                oldPurchaseableSets);
+
+            var oldNonPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear < releaseYearForNewSets && !s.IsPurchaseableSet());
+            await this.BuildAndSendLegoSetNotificationsAsync(
+                new LegoSetBatchNotification.NotificationSettings() { Label = "Old Non-Purchaseable Sets", IncludeAttachments = false },
+                oldNonPurchaseableSets);
+
+            var newPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear >= releaseYearForNewSets && s.IsPurchaseableSet());
+            await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NewLegoSetNotificationSettings, newPurchaseableSets);
+
+            var newNonPurchaseableSets = notYetNotifiedSets.Where(s => s.ReleaseYear >= releaseYearForNewSets && !s.IsPurchaseableSet());
+            await this.BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NonPurchaseableLegoSetNotificationSettings, newNonPurchaseableSets);
+        }
+
+        private async Task BuildAndSendLegoSetNotificationsAsync(LegoSetBatchNotification.NotificationSettings settings, IEnumerable<RebrickableData.LegoSet> legoSets)
+        {
+            if (this.notifier == null)
+            {
+                return;
+            }
+
+            var batches = LegoSetBatchNotification.BuildNotifications(this.notifier, settings, legoSets);
+            foreach (var notification in batches)
             {
                 try
                 {
@@ -90,22 +114,24 @@ namespace LegoSetNotifier
                         await this.seenData.MarkSetsAsNotifiedAsync(notifiedAtTime, notifiedSetNumbers);
 
                         this.logger.LogInformation(
-                            "Sent notification(s) of {NumberOfNotifiedSets} new sets as of {NotifiedAtTime}",
+                            "Sent a {NotificationLabel} notification for {NumberOfSets} sets as of {NotifiedAtTime}",
+                            settings.Label,
                             notifiedSetNumbers.Count,
                             notifiedAtTime);
                     }
                     else
                     {
                         this.logger.LogError(
-                            "Failed to send notification(s) for {NumberOfNotYetNotifiedSets} new sets",
-                            notYetNotifiedSets.Count());
+                            "Failed to send a {NotificationLabel} notification for {NumberOfSets} sets",
+                            settings.Label,
+                            notification.GetLegoSetNumbers().Count);
                     }
                 }
                 catch (Exception ex)
                 {
-                    const string exceptionErrorMessage = "Exception sending notification(s) of new sets";
+                    const string exceptionErrorMessage = "Exception sending a notification";
                     this.logger.LogError(ex, exceptionErrorMessage);
-                    await notifier.SendErrorNotificationAsync($"An exception occurred while attempting to send notification(s) of {notYetNotifiedSets.Count()} new sets", ex);
+                    await notifier.SendErrorNotificationAsync($"An exception occurred while attempting to send a {settings.Label} notification for {notification.GetLegoSetNumbers().Count} sets", ex);
                 }
             }
         }

--- a/LegoSetNotifier/LocalFilesNotifier.cs
+++ b/LegoSetNotifier/LocalFilesNotifier.cs
@@ -48,7 +48,7 @@ namespace LegoSetNotifier
 
         public async Task<bool> SendLegoSetBatchNotificationAsync(LegoSetBatchNotification notification)
         {
-            return await this.WriteNotificationContentAsFileAsync(notification.GetContent());
+            return await this.WriteNotificationContentAsFileAsync(notification.GetNotificationContent());
         }
 
         private async Task<bool> WriteNotificationContentAsFileAsync(AppriseApi.AppriseApiNotifyContent content)

--- a/LegoSetNotifier/LocalFilesNotifier.cs
+++ b/LegoSetNotifier/LocalFilesNotifier.cs
@@ -1,0 +1,67 @@
+﻿using System.Globalization;
+using System.Text.Json;
+
+namespace LegoSetNotifier
+{
+    public class LocalFilesNotifier : INotifier
+    {
+        private JsonSerializerOptions serializerOptions = new JsonSerializerOptions()
+        {
+            WriteIndented = true,
+        };
+
+        private string baseDir = Path.Combine(Directory.GetCurrentDirectory(), "notifications");
+
+        public LocalFilesNotifier(string notificationFilesDir)
+        {
+            this.baseDir = notificationFilesDir;
+
+            if (!Directory.Exists(this.baseDir))
+            {
+                Directory.CreateDirectory(this.baseDir);
+            }
+        }
+
+        public uint GetMaxNotificationBodyChars()
+        {
+            // Simulate Apprise API constraints.
+            return AppriseApi.AppriseApiClient.MaxBodyChars;
+        }
+
+        public uint GetMaxNotificationAttachments()
+        {
+            // Simulate Apprise API constraints.
+            return AppriseApi.AppriseApiClient.MaxAttachments;
+        }
+
+        public async Task<bool> SendErrorNotificationAsync(string message, Exception? ex)
+        {
+            var notification = new AppriseApi.AppriseApiNotifyContent()
+            {
+                Type = "failure",
+                Title = message,
+                Body = $"{message}\n\n{ex}",
+            };
+
+            return await this.WriteNotificationContentAsFileAsync(notification);
+        }
+
+        public async Task<bool> SendLegoSetBatchNotificationAsync(LegoSetBatchNotification notification)
+        {
+            return await this.WriteNotificationContentAsFileAsync(notification.GetContent());
+        }
+
+        private async Task<bool> WriteNotificationContentAsFileAsync(AppriseApi.AppriseApiNotifyContent content)
+        {
+            var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var filePath = Path.Combine(this.baseDir, nowMs.ToString(CultureInfo.InvariantCulture) + ".json");
+
+            using (var fileStream = File.Open(filePath, FileMode.Create, FileAccess.Write))
+            {
+                await JsonSerializer.SerializeAsync(fileStream, content, this.serializerOptions);
+            }
+
+            return true;
+        }
+    }
+}

--- a/LegoSetNotifier/PreviouslySeenDataJsonFile.cs
+++ b/LegoSetNotifier/PreviouslySeenDataJsonFile.cs
@@ -69,7 +69,7 @@ namespace LegoSetNotifier
             }
         }
 
-        public async Task MarkSetsAsNotifiedAsync(DateTimeOffset notifiedAtTime, HashSet<string> legoSetNumbers)
+        public async Task MarkSetsAsNotifiedAsync(DateTimeOffset notifiedAtTime, ISet<string> legoSetNumbers)
         {
             if (this.Sets == null)
             {

--- a/LegoSetNotifier/PreviouslySeenDataJsonFile.cs
+++ b/LegoSetNotifier/PreviouslySeenDataJsonFile.cs
@@ -1,4 +1,5 @@
 ﻿using LegoSetNotifier.RebrickableData;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -11,13 +12,21 @@ namespace LegoSetNotifier
             IncludeFields = true,
         };
 
+        private const uint ioExceptionRetryCount = 3;
+        private static readonly TimeSpan ioExceptionRetryDelay = TimeSpan.FromMilliseconds(100);
+
         [JsonPropertyName("sets")]
         public Dictionary<string, PreviouslySeenLegoSet>? Sets { get; set; } = null;
 
         [JsonIgnore]
-        private string FilePath = string.Empty;
+        private ILogger? logger = null;
 
-        public static async Task<PreviouslySeenDataJsonFile> FromFilePathAsync(string filePath)
+        [JsonIgnore]
+        private string filePath = string.Empty;
+
+        public static async Task<PreviouslySeenDataJsonFile> FromFilePathAsync(
+            ILogger logger,
+            string filePath)
         {
             try
             {
@@ -29,7 +38,8 @@ namespace LegoSetNotifier
                         throw new InvalidDataException($"Unexpected null result from JSON deserializing {filePath}");
                     }
 
-                    data.FilePath = filePath;
+                    data.logger = logger;
+                    data.filePath = filePath;
                     return data;
                 }
             }
@@ -37,7 +47,8 @@ namespace LegoSetNotifier
             {
                 // This is fine, just start fresh with empty data.
                 var data = new PreviouslySeenDataJsonFile();
-                data.FilePath = filePath;
+                data.logger = logger;
+                data.filePath = filePath;
 
                 return data;
             }
@@ -45,7 +56,7 @@ namespace LegoSetNotifier
 
         public string GetDataSourceName()
         {
-            return this.FilePath;
+            return this.filePath;
         }
 
         public Task<Dictionary<string, PreviouslySeenLegoSet>> GetSetsAsync()
@@ -60,12 +71,32 @@ namespace LegoSetNotifier
 
         public async Task UpdateSetsAsync(Dictionary<string, PreviouslySeenLegoSet> legoSets)
         {
-            // Ensure the filepath is writable before updating the current data.
-            using (var fileStream = File.Open(this.FilePath, FileMode.Create, FileAccess.Write))
+            for (var attempt = 0u; attempt < ioExceptionRetryCount; ++attempt)
             {
-                this.Sets = legoSets;
+                try
+                {
+                    // Ensure the filepath is writable before updating the current data.
+                    using (var fileStream = File.Open(this.filePath, FileMode.Create, FileAccess.Write))
+                    {
+                        this.Sets = legoSets;
 
-                await JsonSerializer.SerializeAsync(fileStream, this);
+                        await JsonSerializer.SerializeAsync(fileStream, this);
+                        break;
+                    }
+                }
+                catch (IOException ex)
+                {
+                    if ((attempt + 1) == ioExceptionRetryCount)
+                    {
+                        this.logger?.LogError(ex, "Writing updated sets encountered an IO exception, aborting after {AttemptCount} attempts", attempt + 1);
+                        throw;
+                    }
+                    else
+                    {
+                        this.logger?.LogError(ex, "Writing updated sets encountered an IO exception, attempt {AttemptCount} will retry up to {AttemptMax}", attempt + 1, ioExceptionRetryCount);
+                        await Task.Delay(ioExceptionRetryDelay);
+                    }
+                }
             }
         }
 
@@ -81,9 +112,29 @@ namespace LegoSetNotifier
                 this.Sets[legoSetNumber].NotifiedAtTime = notifiedAtTime;
             }
 
-            using (var fileStream = File.Open(this.FilePath, FileMode.Create, FileAccess.Write))
+            for (var attempt = 0u; attempt < ioExceptionRetryCount; ++attempt)
             {
-                await JsonSerializer.SerializeAsync(fileStream, this);
+                try
+                {
+                    using (var fileStream = File.Open(this.filePath, FileMode.Create, FileAccess.Write))
+                    {
+                        await JsonSerializer.SerializeAsync(fileStream, this);
+                        break;
+                    }
+                }
+                catch (IOException ex)
+                {
+                    if ((attempt + 1) == ioExceptionRetryCount)
+                    {
+                        this.logger?.LogError(ex, "Marking notified sets encountered an IO exception, aborting after {AttemptCount} attempts", attempt + 1);
+                        throw;
+                    }
+                    else
+                    {
+                        this.logger?.LogError(ex, "Marking notified sets encountered an IO exception, attempt {AttemptCount} will retry up to {AttemptMax}", attempt + 1, ioExceptionRetryCount);
+                        await Task.Delay(ioExceptionRetryDelay);
+                    }
+                }
             }
         }
     }

--- a/LegoSetNotifier/Program.cs
+++ b/LegoSetNotifier/Program.cs
@@ -68,7 +68,7 @@ namespace LegoSetNotifier
 
             try
             {
-                var seenData = await PreviouslySeenDataJsonFile.FromFilePathAsync(dataFilePath);
+                var seenData = await PreviouslySeenDataJsonFile.FromFilePathAsync(logger, dataFilePath);
 
                 using (var dataClient = new RebrickableDataClient())
                 {

--- a/LegoSetNotifier/Program.cs
+++ b/LegoSetNotifier/Program.cs
@@ -17,6 +17,7 @@ namespace LegoSetNotifier
             var dataFilePath = "previouslySeen.json";
             var appriseApiBaseUrl = string.Empty;
             var appriseApiConfigKey = string.Empty;
+            var notificationFilesDir = string.Empty;
 
             var options = new OptionSet()
             {
@@ -24,6 +25,7 @@ namespace LegoSetNotifier
                 { "f|data-file=", $"Data file path, default: {dataFilePath}", o => dataFilePath = o },
                 { "a|apprise-api-baseurl=", $"Apprise API base URL, default: {appriseApiBaseUrl}", o => appriseApiBaseUrl = o },
                 { "k|apprise-api-configkey=", $"Apprise API config key, default: {appriseApiConfigKey}", o => appriseApiConfigKey = o },
+                { "notification-files-dir=", $"If specified, local directory for writing notifications as files", o => notificationFilesDir = o },
             };
             options.Parse(args);
 
@@ -33,30 +35,39 @@ namespace LegoSetNotifier
                 return 0;
             }
 
-            // Options validation: either both Apprise API [base URL + config key] must be specified, or neither.
-            if (!string.IsNullOrEmpty(appriseApiBaseUrl) && string.IsNullOrEmpty(appriseApiConfigKey))
-            {
-                logger.LogError("Invalid options, cannot only provide Apprise API base URL (must also provide config key)");
-                options.WriteOptionDescriptions(Console.Out);
-                return -1;
-            }
-            else if (!string.IsNullOrEmpty(appriseApiConfigKey) && string.IsNullOrEmpty(appriseApiBaseUrl))
-            {
-                logger.LogError("Invalid options, cannot only provide Apprise API config key (must also provide base URL)");
-                options.WriteOptionDescriptions(Console.Out);
-                return -1;
-            }
-
             AppriseApiClient? appriseClient = null;
             INotifier? notifier = null;
-            try
+            if (!string.IsNullOrEmpty(notificationFilesDir))
             {
-                if (!string.IsNullOrEmpty(appriseApiBaseUrl))
+                notifier = new LocalFilesNotifier(notificationFilesDir);
+
+                if (!string.IsNullOrEmpty(appriseApiBaseUrl) || !string.IsNullOrEmpty(appriseApiConfigKey))
                 {
-                    appriseClient = new AppriseApiClient(appriseApiBaseUrl);
-                    notifier = new AppriseNotifier(appriseClient, appriseApiConfigKey);
+                    logger.LogWarning("Ignoring Apprise API notifier options, because a local files notifier is being used instead");
+                }
+            }
+            else if (!string.IsNullOrEmpty(appriseApiBaseUrl) || !string.IsNullOrEmpty(appriseApiConfigKey))
+            {
+                // If one Apprise API option (base URL or config key) was specified, but the other is missing, that's a usage error.
+                if (string.IsNullOrEmpty(appriseApiConfigKey))
+                {
+                    logger.LogError("Invalid options, cannot only provide Apprise API base URL (must also provide config key)");
+                    options.WriteOptionDescriptions(Console.Out);
+                    return -1;
+                }
+                else if (string.IsNullOrEmpty(appriseApiBaseUrl))
+                {
+                    logger.LogError("Invalid options, cannot only provide Apprise API config key (must also provide base URL)");
+                    options.WriteOptionDescriptions(Console.Out);
+                    return -1;
                 }
 
+                appriseClient = new AppriseApiClient(appriseApiBaseUrl);
+                notifier = new AppriseNotifier(appriseClient, appriseApiConfigKey);
+            }
+
+            try
+            {
                 var seenData = await PreviouslySeenDataJsonFile.FromFilePathAsync(dataFilePath);
 
                 using (var dataClient = new RebrickableDataClient())

--- a/LegoSetNotifier/Program.cs
+++ b/LegoSetNotifier/Program.cs
@@ -77,7 +77,7 @@ namespace LegoSetNotifier
 
                     if (notifier != null)
                     {
-                        await legoSetNotifier.SendNewSetNotificationsAsync();
+                        await legoSetNotifier.SendNotificationsAsync(DateTimeOffset.UtcNow.Year);
                     }
                 }
             }

--- a/LegoSetNotifier/RebrickableData/LegoSet.cs
+++ b/LegoSetNotifier/RebrickableData/LegoSet.cs
@@ -5,7 +5,7 @@ namespace LegoSetNotifier.RebrickableData
 {
     public class LegoSet
     {
-        private readonly Regex PurchaseableSetNumberPattern = new Regex(@"^[0-9]{5}$", RegexOptions.Compiled);
+        private static readonly Regex PurchaseableSetNumberPattern = new Regex(@"^[0-9]{5}$", RegexOptions.Compiled);
 
         [JsonPropertyName("ExtendedSetNumber")]
         public string ExtendedSetNumber { get; set; } = string.Empty;


### PR DESCRIPTION
To generally reduce the number of notifications produced, this set of changes implements alternate NotificationSettings:

- A "digest" form will omit attachments, batching Lego sets into fewer notifications (within message-body constraints).
- A "summary" form will omit all per-set detail, simply providing an overall count of Lego sets.

When seen-data is empty and being initialized for the first time, a simple summary will cover all sets which are older than the current year OR which are not purchaseable. Then a small number of digest notifications will describe new and purchaseable sets.

In the typical case (updating seen-data), digests will be used for non-purchaseable sets, or for sets which are somehow older than the current year. New and purchaseable sets will be notified with attachment images, as before.